### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appknox.yml
+++ b/.github/workflows/appknox.yml
@@ -21,6 +21,10 @@
 
 name: Appknox
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/pavel13374/DiCheck/security/code-scanning/1](https://github.com/pavel13374/DiCheck/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required. Based on the workflow's functionality:
1. The `contents: read` permission is needed to check out the repository code.
2. The `security-events: write` permission is required to upload SARIF files to GitHub Advanced Security.

These permissions will be explicitly defined to ensure the workflow operates securely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
